### PR TITLE
Update requirements.txt 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.0
 Jinja2==2.10
-Werkzeug==0.15.3
+Werkzeug==0.15.5
 MarkupSafe==1.1.1
 itsdangerous==0.24
 PyQt5==5.15.0


### PR DESCRIPTION
(TypeError: required field “type_ignores” missing from Module) is fixed in werkzeug 0.15.5.