### PR TITLE
Add PyQtWebEngine to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Werkzeug==0.15.5
 MarkupSafe>=1.1.1
 itsdangerous==0.24
 PyQt5==5.15.0
+PyQtWebEngine==5.15.2


### PR DESCRIPTION
After an issue I had during the installation of this module is `PyQtWebEngine` utilities, advanced python coders might know how to fix this issue but I believe that some beginners might stumble into this issue and will skip working with this specific module that you made (Which is really helpful ngl, **Big thanks for that**).

So...
I added this simple PyQtWebEngine module to ``requirements.txt`` so it will auto-install with the rest of the required modules!
I inserted the version I found to be good to work with this module which is the latest (for the time of this PR)

- Yon :)