### PR TITLE
fix PySide2 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Jinja2==2.11.3
 Werkzeug==0.15.5
 MarkupSafe>=1.1.1
 itsdangerous==0.24
-PySide2==5.15.2
+PySide2==5.15.2.1


### PR DESCRIPTION
This fixes following error during pip install:

```
ERROR: Could not find a version that satisfies the requirement PySide2==5.15.2 (from webui) (from versions: 0.0.0a1, 5.11.0, 5.11.1, 5.11.2, 5.12.0, 5.12.1, 5.12.2, 5.12.3, 5.12.4, 5.12.5, 5.12.6, 5.13.0, 5.13.1, 5.13.2, 5.15.2.1)
ERROR: No matching distribution found for PySide2==5.15.2
```
